### PR TITLE
fill promise resolver when componentDidMount and componentDidUpdate phase

### DIFF
--- a/src/google-recaptcha-provider.tsx
+++ b/src/google-recaptcha-provider.tsx
@@ -82,6 +82,7 @@ export class GoogleReCaptchaProvider extends React.Component<
      * return to avoid duplicated scripts
      */
     if (document.getElementById(this.scriptId)) {
+      this.handleOnLoad();
       return;
     }
 


### PR DESCRIPTION
This PR fixes #13. When component remounts promise did not fill with `grecaptcha` therefore promise stays at pending status forever. 
