### PR TITLE
Support to reCaptcha Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ npm install react-google-recaptcha-v3
 
 To use `react-google-recaptcha-v3`, you need to create a recaptcha key for your domain, you can get one from [here](https://www.google.com/recaptcha/intro/v3.html).
 
+#### Enterprise
+
+When you enable to use the enterprise version, **you must create new keys**. These keys will replace any Site Keys you created in reCAPTCHA. Check the [migration guide](https://cloud.google.com/recaptcha-enterprise/docs/migrate-recaptcha).
+
+To work properly, you **must** select the Integration type to be `Scoring` since is equivalent to the reCAPTCHA v3.
+
+The complete documentation to the enterprise version you can see [here](https://cloud.google.com/recaptcha-enterprise/docs/quickstart).
+
 #### Components
 
 ##### GoogleReCaptchaProvider
@@ -51,6 +59,7 @@ ReactDom.render(
     reCaptchaKey="[Your recaptcha key]"
     language="[optional_language]"
     useRecaptchaNet="[optional_boolean_value]"
+    enterprise="[optional_boolean_value]"
     scriptProps={{
       async: false, // optional, default to false,
       defer: false // optional, default to false

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ReactDom.render(
     reCaptchaKey="[Your recaptcha key]"
     language="[optional_language]"
     useRecaptchaNet="[optional_boolean_value]"
-    enterprise="[optional_boolean_value]"
+    useEnterprise="[optional_boolean_value]"
     scriptProps={{
       async: false, // optional, default to false,
       defer: false // optional, default to false

--- a/__tests__/google-recaptcha-provider.test.tsx
+++ b/__tests__/google-recaptcha-provider.test.tsx
@@ -103,10 +103,10 @@ describe('<GoogleReCaptchaProvider />', () => {
     expect(grecaptchaMock.ready).toBeCalled();
   });
 
-  describe('when usign enterprise version', () => {
+  describe('when using enterprise version', () => {
     it('accept an enterprise prop to load recaptcha from enterprise source', () => {
       const mountedComponent = Enzyme.mount(
-        <GoogleReCaptchaProvider reCaptchaKey="TESTKEY" enterprise>
+        <GoogleReCaptchaProvider reCaptchaKey="TESTKEY" useEnterprise>
           <div />
         </GoogleReCaptchaProvider>
       );
@@ -123,7 +123,7 @@ describe('<GoogleReCaptchaProvider />', () => {
       const mountedComponent = Enzyme.mount(
         <GoogleReCaptchaProvider
           reCaptchaKey="TESTKEY"
-          enterprise
+          useEnterprise
           useRecaptchaNet
         >
           <div />
@@ -140,7 +140,7 @@ describe('<GoogleReCaptchaProvider />', () => {
 
     it('handle load the enterprise script', () => {
       Enzyme.mount(
-        <GoogleReCaptchaProvider reCaptchaKey="TESTKEY" enterprise>
+        <GoogleReCaptchaProvider reCaptchaKey="TESTKEY" useEnterprise>
           <div />
         </GoogleReCaptchaProvider>
       );

--- a/__tests__/google-recaptcha-provider.test.tsx
+++ b/__tests__/google-recaptcha-provider.test.tsx
@@ -2,7 +2,31 @@ import Enzyme from 'enzyme';
 import * as React from 'react';
 import { GoogleReCaptchaProvider } from 'src/google-recaptcha-provider';
 
+interface CaptchaMockI {
+  ready: jest.Mock;
+  execute: jest.Mock;
+}
+
+interface GrecaptchaMockI extends CaptchaMockI {
+  enterprise: CaptchaMockI;
+}
+
 describe('<GoogleReCaptchaProvider />', () => {
+  let grecaptchaMock: GrecaptchaMockI;
+
+  beforeAll(() => {
+    grecaptchaMock = {
+      ready: jest.fn(),
+      execute: jest.fn(),
+      enterprise: { ready: jest.fn(), execute: jest.fn() }
+    };
+    (window as any).grecaptcha = grecaptchaMock;
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('accept a useRecaptchaNet prop to load recaptcha from recaptcha.net', () => {
     const mountedComponent = Enzyme.mount(
       <GoogleReCaptchaProvider reCaptchaKey="TESTKEY" useRecaptchaNet>
@@ -50,5 +74,78 @@ describe('<GoogleReCaptchaProvider />', () => {
     expect(googleRecaptchaScript.outerHTML).toEqual(
       `<script id="google-recaptcha-v3" src="https://www.google.com/recaptcha/api.js?render=TESTKEY" nonce="NONCE" defer=""></script>`
     );
+  });
+
+  it('execute recaptcha method correctly', async () => {
+    const mountedComponent = Enzyme.mount(
+      <GoogleReCaptchaProvider reCaptchaKey="TESTKEY">
+        <div />
+      </GoogleReCaptchaProvider>
+    );
+
+    const googleReCaptchaProvider = mountedComponent.instance() as GoogleReCaptchaProvider;
+    googleReCaptchaProvider.grecaptcha = Promise.resolve(grecaptchaMock);
+
+    await (mountedComponent.instance() as GoogleReCaptchaProvider).executeRecaptcha(
+      'test'
+    );
+
+    expect(grecaptchaMock.execute).toBeCalled();
+  });
+
+  it('handle load the default script', () => {
+    Enzyme.mount(
+      <GoogleReCaptchaProvider reCaptchaKey="TESTKEY">
+        <div />
+      </GoogleReCaptchaProvider>
+    );
+
+    expect(grecaptchaMock.ready).toBeCalled();
+  });
+
+  describe('when usign enterprise version', () => {
+    it('accept an enterprise prop to load recaptcha from enterprise source', () => {
+      const mountedComponent = Enzyme.mount(
+        <GoogleReCaptchaProvider reCaptchaKey="TESTKEY" enterprise>
+          <div />
+        </GoogleReCaptchaProvider>
+      );
+
+      const googleRecaptchaSrc = (mountedComponent.instance() as GoogleReCaptchaProvider)
+        .googleRecaptchaSrc;
+
+      expect(googleRecaptchaSrc).toEqual(
+        'https://www.google.com/recaptcha/enterprise.js'
+      );
+    });
+
+    it('should not load recaptcha from recaptcha.net', () => {
+      const mountedComponent = Enzyme.mount(
+        <GoogleReCaptchaProvider
+          reCaptchaKey="TESTKEY"
+          enterprise
+          useRecaptchaNet
+        >
+          <div />
+        </GoogleReCaptchaProvider>
+      );
+
+      const googleRecaptchaSrc = (mountedComponent.instance() as GoogleReCaptchaProvider)
+        .googleRecaptchaSrc;
+
+      expect(googleRecaptchaSrc).toEqual(
+        'https://www.google.com/recaptcha/enterprise.js'
+      );
+    });
+
+    it('handle load the enterprise script', () => {
+      Enzyme.mount(
+        <GoogleReCaptchaProvider reCaptchaKey="TESTKEY" enterprise>
+          <div />
+        </GoogleReCaptchaProvider>
+      );
+
+      expect(grecaptchaMock.enterprise.ready).toBeCalled();
+    });
   });
 });

--- a/src/google-recaptcha-provider.tsx
+++ b/src/google-recaptcha-provider.tsx
@@ -8,6 +8,7 @@ interface IGoogleReCaptchaProviderProps {
   reCaptchaKey?: string;
   language?: string;
   useRecaptchaNet?: boolean;
+  enterprise?: boolean;
   scriptProps?: {
     nonce?: string;
     defer?: boolean;
@@ -44,10 +45,12 @@ export class GoogleReCaptchaProvider extends React.Component<IGoogleReCaptchaPro
   });
 
   get googleRecaptchaSrc() {
-    const { useRecaptchaNet } = this.props;
-    const hostName = useRecaptchaNet ? 'recaptcha.net' : 'google.com';
+    const { useRecaptchaNet, enterprise } = this.props;
+    const hostName =
+      useRecaptchaNet && !enterprise ? 'recaptcha.net' : 'google.com';
+    const script = enterprise ? 'enterprise.js' : 'api.js';
 
-    return `https://www.${hostName}/recaptcha/api.js`;
+    return `https://www.${hostName}/recaptcha/${script}`;
   }
 
   get googleReCaptchaContextValue() {
@@ -99,14 +102,20 @@ export class GoogleReCaptchaProvider extends React.Component<IGoogleReCaptchaPro
   };
 
   handleOnLoad = () => {
+    const { enterprise } = this.props;
+
     if (!window || !(window as any).grecaptcha) {
       console.warn(GoogleRecaptchaError.SCRIPT_NOT_AVAILABLE);
-
       return;
     }
 
-    (window as any).grecaptcha.ready(() => {
-      this.resolver((window as any).grecaptcha);
+    let _grecaptcha = (window as any).grecaptcha;
+    if (enterprise) {
+      _grecaptcha = _grecaptcha.enterprise;
+    }
+
+    _grecaptcha.ready(() => {
+      this.resolver(_grecaptcha);
     });
   };
 

--- a/src/google-recaptcha-provider.tsx
+++ b/src/google-recaptcha-provider.tsx
@@ -8,7 +8,7 @@ interface IGoogleReCaptchaProviderProps {
   reCaptchaKey?: string;
   language?: string;
   useRecaptchaNet?: boolean;
-  enterprise?: boolean;
+  useEnterprise?: boolean;
   scriptProps?: {
     nonce?: string;
     defer?: boolean;
@@ -45,10 +45,10 @@ export class GoogleReCaptchaProvider extends React.Component<IGoogleReCaptchaPro
   });
 
   get googleRecaptchaSrc() {
-    const { useRecaptchaNet, enterprise } = this.props;
+    const { useRecaptchaNet, useEnterprise } = this.props;
     const hostName =
-      useRecaptchaNet && !enterprise ? 'recaptcha.net' : 'google.com';
-    const script = enterprise ? 'enterprise.js' : 'api.js';
+      useRecaptchaNet && !useEnterprise ? 'recaptcha.net' : 'google.com';
+    const script = useEnterprise ? 'enterprise.js' : 'api.js';
 
     return `https://www.${hostName}/recaptcha/${script}`;
   }
@@ -102,20 +102,19 @@ export class GoogleReCaptchaProvider extends React.Component<IGoogleReCaptchaPro
   };
 
   handleOnLoad = () => {
-    const { enterprise } = this.props;
+    const { useEnterprise } = this.props;
 
     if (!window || !(window as any).grecaptcha) {
       console.warn(GoogleRecaptchaError.SCRIPT_NOT_AVAILABLE);
       return;
     }
 
-    let _grecaptcha = (window as any).grecaptcha;
-    if (enterprise) {
-      _grecaptcha = _grecaptcha.enterprise;
-    }
+    const grecaptcha = useEnterprise
+      ? (window as any).grecaptcha.enterprise
+      : (window as any).grecaptcha;
 
-    _grecaptcha.ready(() => {
-      this.resolver(_grecaptcha);
+    grecaptcha.ready(() => {
+      this.resolver(grecaptcha);
     });
   };
 


### PR DESCRIPTION
I was requested to use the enterprise version of reCaptcha. Since we already using this library, I figured that is not too hard to make it works with this paid version of Captcha. The enterprise version is totally compatible since we chose the right Integration type, which is Scoring.

I created a new boolean prop called `enterprise` that loads the enterprise script and changes the call of `grecaptcha` as requested in the official docs. I followed the [migration guide](https://cloud.google.com/recaptcha-enterprise/docs/migrate-recaptcha). 