### PR TITLE
Fixed the scriptProps object in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ ReactDom.render(
     useEnterprise="[optional_boolean_value]"
     scriptProps={{
       async: false, // optional, default to false,
-      defer: false // optional, default to false
-      appendTo: "head" // optional, default to "head", can be "head" or "body",
+      defer: false, // optional, default to false
+      appendTo: "head", // optional, default to "head", can be "head" or "body",
       nonce: undefined // optional, default undefined
     }}
   >


### PR DESCRIPTION
The scriptProps object in the main example was missing commas(,).