### PR TITLE
Add support for loading Enterprise Recaptcha from `recaptcha.net`

### DIFF
--- a/__tests__/google-recaptcha-provider.test.tsx
+++ b/__tests__/google-recaptcha-provider.test.tsx
@@ -94,7 +94,7 @@ describe('<GoogleReCaptchaProvider />', () => {
       );
     });
 
-    it('should not load recaptcha from recaptcha.net', () => {
+    it('should load recaptcha from recaptcha.net', () => {
       render(
         <GoogleReCaptchaProvider
           reCaptchaKey="TESTKEY"
@@ -108,7 +108,7 @@ describe('<GoogleReCaptchaProvider />', () => {
       const scriptElm = document.getElementById('google-recaptcha-v3');
 
       expect(scriptElm!.getAttribute('src')).toEqual(
-        'https://www.google.com/recaptcha/enterprise.js?render=TESTKEY'
+        'https://www.recaptcha.net/recaptcha/enterprise.js?render=TESTKEY'
       );
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,8 +26,7 @@ const generateGoogleRecaptchaSrc = ({
   useRecaptchaNet: boolean;
   useEnterprise: boolean;
 }) => {
-  const hostName =
-    useRecaptchaNet && !useEnterprise ? 'recaptcha.net' : 'google.com';
+  const hostName = useRecaptchaNet ? 'recaptcha.net' : 'google.com';
   const script = useEnterprise ? 'enterprise.js' : 'api.js';
 
   return `https://www.${hostName}/recaptcha/${script}`;


### PR DESCRIPTION
Resolves #103 

This PR modifies the logic to allow Enterprise ReCAPTCHA to work from `recaptcha.net`.