### PR TITLE
update readme recommended example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ const YourReCaptchaComponent = () => {
 
     const token = await executeRecaptcha('yourAction');
     // Do whatever you want with the token
-  }, []);
+  }, [executeRecaptcha]);
 
   // You can use useEffect to trigger the verification as soon as the component being loaded
   useEffect(() => {


### PR DESCRIPTION
The `executeRecaptcha` dependency is needed for the example snippet to work.  Mentioned in this comment too https://github.com/t49tran/react-google-recaptcha-v3/issues/73#issuecomment-910117949 