### PR TITLE
Change peerDependencies to react@17.0 and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "url": "https://github.com/t49tran/react-google-recaptcha-v3"
   },
   "peerDependencies": {
-    "react": "^17.0",
-    "react-dom": "^17.0"
+    "react": ">=17.0",
+    "react-dom": ">=17.0"
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2"


### PR DESCRIPTION
This will allow this package to be use in react@18 without need to force install.