### PR TITLE
Add back React 16.3 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/t49tran/react-google-recaptcha-v3"
   },
   "peerDependencies": {
-    "react": "^17.0 || ^18.0",
+    "react": "^16.3 || ^17.0 || ^18.0",
     "react-dom": "^17.0 || ^18.0"
   },
   "dependencies": {


### PR DESCRIPTION
It's compatible alright. The API is the same, so this version should be there. 

Other dependencies in some projects prevent the upgrade and maybe don't want to force people to use `--force` or `--legacy-peer-deps`.