### PR TITLE
Add back React DOM 16.3 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "react": "^16.3 || ^17.0 || ^18.0",
-    "react-dom": "^17.0 || ^18.0"
+    "react-dom": "^16.3 || ^17.0 || ^18.0"
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2"


### PR DESCRIPTION
Following up on https://github.com/t49tran/react-google-recaptcha-v3/pull/148#issuecomment-1257443220