### PR TITLE
React DOM support fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "react": "^16.3 || ^17.0 || ^18.0",
-    "react-dom": "^17.0 || ^18.0"
+    "react-dom": "^16.3 || ^17.0 || ^18.0"
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2"


### PR DESCRIPTION
in peerDep min version of react is 16.3 but dom is 17. This commit fix this minor mistake